### PR TITLE
Fix of the dpl_openwrite function

### DIFF
--- a/libdroplet/src/vfile.c
+++ b/libdroplet/src/vfile.c
@@ -257,7 +257,7 @@ dpl_openwrite(dpl_ctx_t *ctx,
           // and that we should concat the rest of the locator instead.
           obj_ino = parent_ino;
           if (remote_name[0] == '\0')
-              strcat(obj_ino.key, &locator[strlen(path)]);
+              strcat(obj_ino.key, &locator[path - nlocator + strlen(path)]);
           else
               strcat(obj_ino.key, remote_name); //XXX check length
           obj_type = DPL_FTYPE_REG;


### PR DESCRIPTION
the dpl_openwrite function had a reproductible bug that I fixed in a fork of your Droplet library here on github.
It is a tiny patch, but really useful.

See the commit message at the url for information about the patch and the bug :
https://github.com/Joacchim/Droplet/commit/60facf1d51ccd067bfcd9afc6e9d88cb41f75c86
