### PR TITLE
Enhancement in dpl_openwrite() regarding the EXCL flag

### DIFF
--- a/libdroplet/src/vfile.c
+++ b/libdroplet/src/vfile.c
@@ -272,7 +272,7 @@ dpl_openwrite(dpl_ctx_t *ctx,
     {
       if (vfile->flags & DPL_VFILE_FLAG_EXCL)
         {
-          ret = DPL_FAILURE;
+          ret = DPL_EEXIST;
           goto end;
         }
     }


### PR DESCRIPTION
This change allow the caller to determine if the failure was caused by the file
already existing or another error.
