### PR TITLE
CSV pricing file location is not appropriate

### DIFF
--- a/libdroplet/include/droplet.h
+++ b/libdroplet/include/droplet.h
@@ -322,6 +322,7 @@ typedef struct dpl_ctx
   char *droplet_dir;
   char *profile_name;
 
+  char *pricing_dir; /*!< where charged events should be logged, empty string to disable logging */
   FILE *event_log; /*!< log charged events */
 
   dpl_trace_func_t trace_func;

--- a/libdroplet/src/pricing.c
+++ b/libdroplet/src/pricing.c
@@ -1051,8 +1051,11 @@ dpl_log_event(dpl_ctx_t *ctx,
 {
   time_t t;
 
-  t = time(0);
-  fprintf(ctx->event_log, "%ld;%s;%s;%llu\n", t, type, subtype, (unsigned long long) size);
+  if (NULL != ctx->event_log)
+    {
+      t = time(0);
+      fprintf(ctx->event_log, "%ld;%s;%s;%llu\n", t, type, subtype, (unsigned long long) size);
+    }
   return DPL_SUCCESS;
 }
 


### PR DESCRIPTION
This is a fix for ticket #99. The directory where requests are logged can be specified in the profile using the key pricing_dir. If not specified, the directory defaults to the droplet directory. If specified but left empty, logging is disabled.
