### PR TITLE
 droplet/dplsh: with S3 backend, doing "cd bucket_name" sticks the comma...

### DIFF
--- a/libdroplet/src/conn.c
+++ b/libdroplet/src/conn.c
@@ -565,8 +565,16 @@ dpl_try_connect(dpl_ctx_t *ctx,
 
   if (NULL == conn)
     {
-      dpl_blacklist_host(ctx, host, portstr);
-      goto retry;
+      if (req->behavior_flags & DPL_BEHAVIOR_VIRTUAL_HOSTING)
+        {
+          ret = DPL_FAILURE;
+          goto end;
+        }
+      else
+        {
+          dpl_blacklist_host(ctx, host, portstr);
+          goto retry;
+        }
     }
 
   ret2 = dpl_req_set_host(req, hostp);

--- a/libdroplet/src/vfs.c
+++ b/libdroplet/src/vfs.c
@@ -790,16 +790,6 @@ dpl_chdir(dpl_ctx_t *ctx,
 
   DPL_TRACE(ctx, DPL_TRACE_VFS, "chdir locator=%s", locator);
 
-  /* sanity checks */
-  if (NULL == strchr(locator, ':'))
-    {
-      if (! ctx->cur_bucket || 0 == strlen(ctx->cur_bucket))
-        {
-          ret = DPL_ENOENT;
-          goto end;
-        }
-    }
-
   nlocator = strdup(locator);
   if (NULL == nlocator)
     {


### PR DESCRIPTION
...nd-line

The main problem was in the wrong handling of blacklist address in case of virtual hosting mode.
With an invalid bucket, we ended invalidating the only address we used, thus resulting in a very
dire situation were no operation can be performed.

We simply chose to deny address blacklisting in vhost mode
