### PR TITLE
Why do we need to include xattr.h twice? Removed attr/xattr.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,8 +32,8 @@ AC_PROG_YACC
 
 AC_ARG_WITH(json_c_include_dir,
         [  --with-json-c-include-dir=
-			  Specify json-c include dir [default=/usr/local/include/json-c]],
-        [json_c_include_dir="$withval"],[json_c_include_dir="/usr/local/include/json-c"])
+			  Specify json-c include dir [default=/usr/include/json]],
+        [json_c_include_dir="$withval"],[json_c_include_dir="/usr/include/json"])
 
 json_c_include_dir="$(cd $json_c_include_dir ; pwd)"
 

--- a/libdroplet/posix/backend.c
+++ b/libdroplet/posix/backend.c
@@ -39,7 +39,6 @@
 #include <dirent.h>
 #include <sys/types.h>
 #include <linux/xattr.h>
-#include <attr/xattr.h>
 #include <utime.h>
 #include <pwd.h>
 #include <grp.h>


### PR DESCRIPTION
I tried to build on CentOS 6. I noticed that there two issues with a new install.

configure.ac is looking for json-c in /usr/local/include/json-c. In you install json-c-devel the directory is /usr/include/json. 

backend.c in libdroplet/posix includes xattr.h twice, once from linux and once from attr (under /usr/include). I can not file a file attr/xattr.h owned by a package. I believe we only need to include 1 version of xattr.h and the one in /usr/include/linux appears to work.
