### PR TITLE
Fix bug #183

### DIFF
--- a/libdroplet/src/backend/posix/reqbuilder.c
+++ b/libdroplet/src/backend/posix/reqbuilder.c
@@ -156,10 +156,10 @@ dpl_posix_setattr(const char *path,
     {
       ret2 = dpl_dict_iterate(metadata, cb_posix_setattr, (char *) path);
       if (DPL_SUCCESS != ret2)
-        {
+      {
           ret = ret2;
           goto end;
-        }
+      }
     }
      
   ret = DPL_SUCCESS;


### PR DESCRIPTION
A metadata dictionary read from a posix backend could not previously be
written to another posix backend because the updated function didn't
take care of selecting the metadata subdict for the extended attributes
if any.
This patch provides a retro-compatible way to manage this, while avoiding
the previous assert.