### PR TITLE
Fix bug #184

### DIFF
--- a/libdroplet/src/backend/posix/backend.c
+++ b/libdroplet/src/backend/posix/backend.c
@@ -253,7 +253,7 @@ dpl_posix_head_raw(dpl_ctx_t *ctx,
 
   value.type = DPL_VALUE_SUBDICT;
   value.subdict = subdict;
-  subdict = NULL;
+  // dpl_dict_add_value dups the value, so don't prevent freeing subdict
   ret2 = dpl_dict_add_value(metadata, "xattr", &value, 0);
   if (DPL_SUCCESS != ret2)
     {

--- a/libdroplet/src/dict.c
+++ b/libdroplet/src/dict.c
@@ -363,7 +363,7 @@ dpl_dict_print(const dpl_dict_t *dict,
  *
  * @param dict the dict to add an entry to
  * @param key the key for the new
- * @param value the new value to be entered
+ * @param value the new value to be entered, any allocated value is duplicated, not consumed
  * @param lowered if nonzero, @a key is converted to lower case
  * @retval DPL_SUCCESS on success, or
  * @retval DPL_* a Droplet error code on failure


### PR DESCRIPTION
In part of the codebase, calling functions to add some data consumes
the pointer given to it, and the developer must then avoid freeing the
resource. In this specific case, the memory isn't consumed, but duplicated,
and the resource given by the caller must be freed later on.

This was the matter at the core of a leak where the memory wasn't consumed
nor released.