### PR TITLE
Add a empty_folder_emulation flag in the profile

### DIFF
--- a/libdroplet/include/droplet.h
+++ b/libdroplet/include/droplet.h
@@ -525,6 +525,7 @@ typedef struct dpl_ctx
   unsigned int read_buf_size;
   char *encrypt_key;
   int encode_slashes;        /*!< client wants slashes encoded */
+  int empty_folder_emulation;/*!< folders are represented as empty objects (otherwise, they're purely virtual) */
   int keep_alive;            /*!< client supports keep-alive */
   int url_encoding;          /*!< some servers does not handle url encoding */
   int max_redirects;         /*!< maximum number of redirects */

--- a/libdroplet/src/profile.c
+++ b/libdroplet/src/profile.c
@@ -511,6 +511,18 @@ conf_cb_func(void *cb_arg,
           return -1;
         }
     }
+  else if (!strcmp(var, "empty_folder_emulation"))
+    {
+      if (!strcasecmp(value, "true"))
+        ctx->empty_folder_emulation = 1;
+      else if (!strcasecmp(value, "false"))
+        ctx->empty_folder_emulation = 0;
+      else
+        {
+          DPL_LOG(ctx, DPL_ERROR, "invalid boolean value for '%s'", var);
+          return -1;
+        }
+    }
   else if (!strcmp(var, "keep_alive"))
     {
       if (!strcasecmp(value, "true"))


### PR DESCRIPTION
This flag is a flavor that was previously the only way to manage directories in
a S3 bucket. Now, two flavors exists, with the default one completely
simulating directories using the common prefixes in the bucket, and the second
one (which must be activated explicitly) matches the old behavior.

Note: This leads to an inconsistent behavior between Emulated and Non-Emulated:
 - In Emulated mode, opening a directory requires to remove the ending
   delimiter from the path (the backend accesses the empty object representing
   the directory, which name does not contain an ending delimiter)
 - In Non-Emulated mode, opening a directory requires the ending delimiter (the
   backend uses the ending delimiter to identify if it is a directory)

Adresses Issue #191