### PR TITLE
Upstream some basic fixes.

### DIFF
--- a/libdroplet/include/droplet.h
+++ b/libdroplet/include/droplet.h
@@ -402,7 +402,11 @@ typedef struct
   dpl_condition_one_t conds[DPL_COND_MAX];
 } dpl_condition_t;
 
+#ifndef __cplusplus
 typedef enum
+#else
+enum
+#endif
   {
     DPL_OPTION_LAZY                = (1u<<0), /*!< perform a lazy operation */
     DPL_OPTION_HTTP_COMPAT         = (1u<<1), /*!< use HTTP compat mode */
@@ -412,7 +416,12 @@ typedef enum
     DPL_OPTION_EXPECT_VERSION      = (1u<<5), /*!< expect version */
     DPL_OPTION_FORCE_VERSION       = (1u<<6), /*!< force version */
     DPL_OPTION_NOALLOC             = (1u<<7), /*!< caller provides buffer for GETs */
+#ifndef __cplusplus
   } dpl_option_mask_t;
+#else
+  };
+typedef unsigned int dpl_option_mask_t;
+#endif
 
 typedef struct
 {

--- a/libdroplet/include/droplet/vfs.h
+++ b/libdroplet/include/droplet/vfs.h
@@ -34,6 +34,10 @@
 #ifndef __DROPLET_VFS_H__
 #define __DROPLET_VFS_H__ 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * vdir
  */
@@ -129,4 +133,9 @@ dpl_status_t dpl_link(dpl_ctx_t *ctx, const char *src_locator, const char *dst_l
 dpl_status_t dpl_mkdent(dpl_ctx_t *ctx, const char *src_id, const char *dst_locator, dpl_ftype_t object_type);
 dpl_status_t dpl_rmdent(dpl_ctx_t *ctx, const char *src_name, const char *dst_locator);
 dpl_status_t dpl_mvdent(dpl_ctx_t *ctx, const char *src_locator, const char *dst_locator);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/libdroplet/include/droplet/vfs.h
+++ b/libdroplet/include/droplet/vfs.h
@@ -70,8 +70,11 @@ typedef struct
 /*
  * vfile
  */
-
+#ifndef __cplusplus
 typedef enum
+#else
+enum
+#endif
   {
     DPL_VFILE_FLAG_CREAT =   (1u<<0),     /*!< create file if it doesnt exist */
     DPL_VFILE_FLAG_EXCL =    (1u<<1),     /*!< exclusive creation */
@@ -79,7 +82,13 @@ typedef enum
     DPL_VFILE_FLAG_WRONLY =  (1u<<3),     /*!< open in write-only mode */
     DPL_VFILE_FLAG_RDWR =    (1u<<4),     /*!< open in read-write mode */
     DPL_VFILE_FLAG_STREAM =  (1u<<5),     /*!< open in stream mode (required for read/append) */
+#ifndef __cplusplus
   } dpl_vfile_flag_t;
+#else
+  };
+
+typedef unsigned int dpl_vfile_flag_t;
+#endif
 
 typedef struct
 {

--- a/libdroplet/src/backend/posix/backend.c
+++ b/libdroplet/src/backend/posix/backend.c
@@ -466,6 +466,7 @@ dpl_posix_list_bucket(dpl_ctx_t *ctx,
               st.st_size = 0;
             }
           object->size = st.st_size;
+          object->last_modified = st.st_mtime;
 
           switch (entryp->d_type)
           {

--- a/libdroplet/src/profile.c
+++ b/libdroplet/src/profile.c
@@ -844,7 +844,9 @@ dpl_ssl_profile_post(dpl_ctx_t *ctx)
     /* load CRL in the X509_STORE */
     X509_STORE *cert_store;
     X509_CRL *cert_crl; 
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
     X509_VERIFY_PARAM *cert_verif_param;
+#endif
     BIO *in = NULL;
     int ret = 0;
     char *crl_issuer = NULL;
@@ -872,11 +874,13 @@ dpl_ssl_profile_post(dpl_ctx_t *ctx)
     if (NULL != in)
       BIO_free(in);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
     /* set CRL verification */
     cert_verif_param = X509_VERIFY_PARAM_new();
     X509_VERIFY_PARAM_set_flags(cert_verif_param, X509_V_FLAG_CRL_CHECK);
     SSL_CTX_set1_param(ctx->ssl_ctx, cert_verif_param);
     X509_VERIFY_PARAM_free(cert_verif_param);
+#endif
   }
 
   if (ctx->ssl_cert_file != NULL) {


### PR DESCRIPTION
Ok new attempt. This time I left the C enums as is and added some ifdef specifics for C++.
This should address things for C++ while have zero impact on the C definitions.

Dropped the default behavior patch will keep that in our own fork for now. 