### PR TITLE
dpl_gethostbyname2_r() returns NULL for Not Found

### DIFF
--- a/libdroplet/src/addrlist.c
+++ b/libdroplet/src/addrlist.c
@@ -217,7 +217,7 @@ dpl_addrlist_get_byname_nolock(dpl_addrlist_t *addrlist,
 
   free(new_host);
 
-  if (ret != 0)
+  if (ret != 0 || hresult == NULL)
     return NULL;
 
   port = atoi(portstr);


### PR DESCRIPTION
If the hostname wasn't found by dpl_gethostbyname2_r(), it returns
a good status (0) and a NULL hostent pointer.

dpl_addrlist_get_byname_nolock() needs to check both the status and
the hostent pointer to determine if a valid hostent was returned.