### PR TITLE
dpl_s3_head() on a file should return metadata

### DIFF
--- a/libdroplet/src/backend/s3/backend/head.c
+++ b/libdroplet/src/backend/s3/backend/head.c
@@ -58,7 +58,7 @@ dpl_s3_head(dpl_ctx_t *ctx,
    * an empty object is used to create directories, instead of simply using the
    * delimiters in the paths)
    */
-  if (ctx->empty_folder_emulation && resource[strlen(resource)-1] == '/')
+  if (resource[strlen(resource)-1] != '/' || ctx->empty_folder_emulation)
     {
       ret2 = dpl_s3_head_raw(ctx, bucket, resource, subresource, NULL,
                              object_type, condition, &headers_reply, locationp);


### PR DESCRIPTION
dpl_s3_head() on a file (vs a "directory") should return metadata
regardless of the state of empty_folder_emulation.