### PR TITLE
Fix S3 AWS signature version 4 for http (non-SSL)

### DIFF
--- a/libdroplet/src/backend/s3/reqbuilder.c
+++ b/libdroplet/src/backend/s3/reqbuilder.c
@@ -531,7 +531,7 @@ dpl_s3_req_build(const dpl_req_t *req,
    */
   if (req->behavior_flags & DPL_BEHAVIOR_KEEP_ALIVE)
     {
-      ret2 = dpl_dict_add(headers, "Connection", "keep-alive", 0);
+      ret2 = dpl_dict_add(headers, "Connection", "Keep-Alive", 0);
       if (DPL_SUCCESS != ret2)
         {
           ret = DPL_ENOMEM;


### PR DESCRIPTION
S3 AWS signature version 4 was working fine for https (SSL), but
was failing for http (non-SSL). (Signature didn't match.)

Droplet was using a "Connection: keep-alive" header. When I
changed that to "Connection: Keep-Alive", the signature problem
went away. Now S3 AWS signature version 4 works for http (non-SSL)
in addition to https (SSL).

I know that sounds hard to believe. But what led me here was
that the <CanonicalRequest> in the error message from S3 showed
"Keep-Alive", even though Droplet was using "keep-alive". So I
changed Droplet to use "Keep-Alive", and it worked.

I don't know why it originally worked ok for https (SSL).