### PR TITLE
Use PKG_CHECK_MODULES instead of AM_PATH_CHECK

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,8 +30,8 @@ AC_PROG_LN_S
 
 AC_PROG_YACC
 
-dnl PKG_CHECK_MODULES(CHECK, check >= 0.9.4)
-AM_PATH_CHECK(0.9.3) dnl FIXME: It's just for fixing build on Centos 5 but this call is now deprecated
+PKG_CHECK_MODULES(CHECK, check >= 0.9.4)
+dnl AM_PATH_CHECK(0.9.3) dnl Deprecated, but older systems may need this instead of the above
 
 PKG_CHECK_MODULES(LIBXML, libxml-2.0)
 PKG_CHECK_MODULES(OPENSSL, openssl)


### PR DESCRIPTION
AM_PATH_CHECK is deprecated, so we'll use PKG_CHECK_MODULES
and comment out AM_PATH_CHECK, just in case someone needs it
on an older system.