### PR TITLE
Check for NULL hresult from dpl_gethostbyname2_r()

### DIFF
--- a/libdroplet/src/addrlist.c
+++ b/libdroplet/src/addrlist.c
@@ -217,7 +217,7 @@ dpl_addrlist_get_byname_nolock(dpl_addrlist_t *addrlist,
 
   free(new_host);
 
-  if (ret != 0)
+  if (ret != 0 || hresult == NULL)
     return NULL;
 
   port = atoi(portstr);


### PR DESCRIPTION
If dpl_gethostbyname2_r() returns a NULL hresult, the host
wasn't found, and we should just return instead of trying to
use it.